### PR TITLE
use persistent udp connection

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,16 @@ Usage
 -----
 
 ```lua
-local statsd = require "statsd"
+-- require constructor
+local Statsd = require "statsd"
 
-statsd.host = "stats.mysite.com" -- default: 127.0.0.1
-statsd.port = 8888 -- default: 8125
-statsd.namespace = "mysite.stats" -- default: none
+-- create statsd object, which will open up a persistent port
+local statsd = Statsd({
+  host = "stats.mysite.com" -- default: 127.0.0.1
+  port = 8888 -- default: 8125
+  namespace = "mysite.stats" -- default: none
+})
+
 
 statsd.gauge( "users", #my_users_table )
 statsd.counter( "events", 5 )

--- a/src/statsd.lua
+++ b/src/statsd.lua
@@ -6,81 +6,106 @@ local math = require "math"
 local os = require "os"
 local socket = require "socket"
 
-math.randomseed( os.time() )
+math.randomseed(os.time())
 
-module( ..., package.seeall )
-
-host = "127.0.0.1"
-port = 8125
-namespace = nil
-
-function send_to_socket( string )
-  local udp = socket.udp()
-  udp:setpeername( host, port )
-  udp:send( string )
-  udp:close()
+local function send_to_socket(self, string)
+  self.udp:send(string)
 end
 
-function send( stat, delta, kind, sample_rate )
+local function send(self, stat, delta, kind, sample_rate)
   sample_rate = sample_rate or 1
 
   if sample_rate == 1 or math.random() <= sample_rate then
     -- Build prefix
     prefix = ""
-    if namespace ~= nil then prefix = namespace.."." end
+
+    if self.namespace ~= nil then prefix = self.namespace.."." end
+
     -- Escape the stat name
-    stat = stat:gsub( ":", "_" ):gsub( "|", "_" ):gsub( "@", "_" )
+    stat = stat:gsub(":", "_"):gsub("|", "_"):gsub("@", "_")
+
     -- Append the sample rate
     rate = ""
+
     if sample_rate ~= 1 then rate = "|@"..sample_rate end
 
-    send_to_socket( prefix..stat..":"..delta.."|"..kind..rate )
+    self:send_to_socket(prefix..stat..":"..delta.."|"..kind..rate)
   end
 end
 
 -- Record an instantaneous measurement. It's different from a counter in that
 -- the value is calculated by the client rather than the server.
-function gauge( stat, value, sample_rate )
-  send( stat, value, "g", sample_rate )
+local function gauge(self, stat, value, sample_rate)
+  self:send(stat, value, "g", sample_rate)
 end
 
 -- A counter is a gauge whose value is calculated by the statsd server. The
 -- client merely gives a delta value by which to change the gauge value.
-function counter( stat, value, sample_rate )
-  send( stat, value, "c", sample_rate )
+local function counter(self, stat, value, sample_rate)
+  self:send(stat, value, "c", sample_rate)
 end
 
 -- Increment a counter by `value`.
-function increment( stat, value, sample_rate )
-  counter( stat, value, sample_rate )
+local function increment(self, stat, value, sample_rate)
+  self:counter(stat, value, sample_rate)
 end
 
 -- Decrement a counter by `value`.
-function decrement( stat, value, sample_rate )
-  counter( stat, -value, sample_rate )
+local function decrement(self, stat, value, sample_rate)
+  self:counter(stat, -value, sample_rate)
 end
 
 -- A timer is a measure of the number of milliseconds elapsed between a start
 -- and end time, for example the time to complete rendering of a web page for
 -- a user.
-function timer( stat, ms )
-  send( stat, ms, "ms" )
+local function timer(self, stat, ms)
+  self:send(stat, ms, "ms")
 end
 
 -- A histogram is a measure of the distribution of timer values over time,
 -- calculated by the statsd server. Not supported by all statsd implementations.
-function histogram( stat, value )
-  send( stat, value, "h" )
+local function histogram(self, stat, value)
+  self:send(stat, value, "h")
 end
 
 -- A meter measures the rate of events over time, calculated by the Statsd
 -- server. Not supported by all statsd implementations.
-function meter( stat, value )
-  send( stat, value, "m" )
+local function meter(self, stat, value)
+  self:send(stat, value, "m")
 end
 
 -- A set counts unique occurrences of events between flushes. Not supported by
 -- all statsd implementations.
-function set( stat, value )
-  send( stat, value, "s" )
+local function set(self, stat, value)
+  self:send(stat, value, "s")
 end
+
+return function(options)
+  options = options or {}
+
+  local host = options.host or "127.0.0.1"
+  local port = options.port or 8125
+  local namespace = options.namespace or nil
+
+  print(host)
+  print(port)
+  print(namespace)
+
+  local udp = socket.udp()
+  udp:setpeername(host, port)
+
+  return {
+    namespace = namespace,
+    udp = udp,
+    gauge = gauge,
+    counter = counter,
+    increment = increment,
+    decrement = decrement,
+    timer = timer,
+    histogram = histogram,
+    meter = meter,
+    send = send,
+    send_to_socket = send_to_socket
+  }
+end
+

--- a/statsd-2.0.0-1.rockspec
+++ b/statsd-2.0.0-1.rockspec
@@ -1,8 +1,8 @@
 package = "statsd"
-version = "1.0.0-1"
+version = "2.0.0-1"
 source = {
   url = "git://github.com/stvp/lua-statsd-client.git",
-  tag = "1.0.0"
+  tag = "2.0.0"
 }
 description = {
   summary = "Statsd client.",

--- a/statsd_test.lua
+++ b/statsd_test.lua
@@ -1,83 +1,94 @@
-statsd = require "../src/statsd"
+local Statsd = require "../src/statsd"
+local statsd = nil
 
-function assert_udp_received( string )
-  assert.spy( statsd.send_to_socket ).was.called_with( string )
+function assert_udp_received(string)
+  assert.equal(statsd.sent_with, string)
 end
 
-before_each( function()
-  statsd.host = "127.0.0.1"
-  statsd.port = 8125
-  statsd.namespace = nil
-  stub( statsd, "send_to_socket" )
+before_each(function()
+  statsd = nil
+  statsd = Statsd()
+
+  --stub send_to_socket
+  statsd.send_to_socket = function(self, string)
+    self.sent_with = string
+  end
 end)
 
-describe( "gauge", function()
-  it( "sets a simple gauge", function()
-    statsd.gauge( "foo", 10 )
-    assert_udp_received( "foo:10|g" )
+describe("gauge", function()
+  it("sets a simple gauge", function()
+    statsd:gauge("foo", 10)
+    assert_udp_received("foo:10|g")
   end)
 
-  it( "sets a gauge with a namespace", function()
-    statsd.namespace = "cool.dudes"
-    statsd.gauge( "foo", 10 )
-    assert_udp_received( "cool.dudes.foo:10|g" )
+  it("sets a gauge with a namespace", function()
+    statsd = Statsd({
+      namespace = "cool.dudes"
+    })
+
+    statsd.send_to_socket = function(self, string)
+      self.sent_with = string
+    end
+
+    statsd:gauge("foo", 10)
+    assert_udp_received("cool.dudes.foo:10|g")
   end)
   
-  it( "sets a gauge with a sample_rate", function()
-    statsd.gauge( "foo", 10, 2 )
-    assert_udp_received( "foo:10|g|@2" )
+  it("sets a gauge with a sample_rate", function()
+    statsd:gauge("foo", 10, 2)
+    assert_udp_received("foo:10|g|@2")
   end)
 
-  it( "escapes stat names", function()
-    statsd.gauge( "foo:dude|baz@99", 1 )
-    assert_udp_received( "foo_dude_baz_99:1|g" )
-  end)
-end)
-
-describe( "counter", function()
-  it( "counts", function()
-    statsd.counter( "neat", 10 )
-    assert_udp_received( "neat:10|c" )
-  end)
-
-  it( "counts down", function()
-    statsd.counter( "neat", -5 )
-    assert_udp_received( "neat:-5|c" )
+  it("escapes stat names", function()
+    statsd:gauge("foo:dude|baz@99", 1)
+    assert_udp_received("foo_dude_baz_99:1|g")
   end)
 end)
 
-describe( "increment", function()
-  it( "increments", function()
-    statsd.increment( "neat", 5 )
-    assert_udp_received( "neat:5|c" )
+describe("counter", function()
+  it("counts", function()
+    statsd:counter("neat", 10)
+    assert_udp_received("neat:10|c")
+  end)
+
+  it("counts down", function()
+    statsd:counter("neat", -5)
+    assert_udp_received("neat:-5|c")
   end)
 end)
 
-describe( "decrement", function()
-  it( "decrements", function()
-    statsd.decrement( "neat", 5 )
-    assert_udp_received( "neat:-5|c" )
+describe("increment", function()
+  it("increments", function()
+    statsd:increment("neat", 5)
+    assert_udp_received("neat:5|c")
   end)
 end)
 
-describe( "timer", function()
-  it( "records a timer", function()
-    statsd.timer( "cool", 125.3 )
-    assert_udp_received( "cool:125.3|ms" )
+describe("decrement", function()
+  it("decrements", function()
+    statsd:decrement("neat", 5)
+    assert_udp_received("neat:-5|c")
   end)
 end)
 
-describe( "histogram", function()
-  it( "records a histogram", function()
-    statsd.histogram( "cool", 99 )
-    assert_udp_received( "cool:99|h" )
+describe("timer", function()
+  it("records a timer", function()
+    statsd:timer("cool", 125.3)
+    assert_udp_received("cool:125.3|ms")
   end)
 end)
 
-describe( "meter", function()
-  it( "records a meter", function()
-    statsd.meter( "cool", 99 )
-    assert_udp_received( "cool:99|m" )
+describe("histogram", function()
+  it("records a histogram", function()
+    statsd:histogram("cool", 99)
+    assert_udp_received("cool:99|h")
+  end)
+end)
+
+describe("meter", function()
+  it("records a meter", function()
+    statsd:meter("cool", 99)
+    assert_udp_received("cool:99|m")
   end)
 end)
 


### PR DESCRIPTION
Hi there,

lua socket helpfully closes udp connections when an object is garbage collected. This pull request keeps the udp connection open instead of re-opening every request, which makes it super useful for web applications that deal with lots of requests!

Made the tests a wee bit hacky, due to a shortfall in luassert, which we should fix (it was throwing errors on `was.called_with(statsd, string)`, so I overrode `send_to_socket` locally. Yikes!)

Thanks for the library! 
