### PR TITLE
Allow pass several keys in one udp packet

### DIFF
--- a/src/statsd.lua
+++ b/src/statsd.lua
@@ -9,7 +9,7 @@ local socket = require "socket"
 math.randomseed(os.time())
 
 local function send_to_socket(self, string)
-  self.udp:send(string)
+  return self.udp:send(string)
 end
 
 local function make_statsd_message(self, stat, delta, kind, sample_rate)
@@ -29,7 +29,7 @@ local function make_statsd_message(self, stat, delta, kind, sample_rate)
   return prefix..stat..":"..delta.."|"..kind..rate
 end
 
-local function send(self, stat, delta, kind, sample_rate)
+local function send(self, stat, delta, kind, sample_rate, neg)
   local msg
   local stat_type = type(stat)
   if stat_type == 'table' then sample_rate = delta end
@@ -41,6 +41,13 @@ local function send(self, stat, delta, kind, sample_rate)
   if stat_type == 'table' then
     local t = {}
     for s, v in pairs(stat) do
+      if kind == 'c' then
+        if type(s) == 'number' then
+          -- this is array or kyes ( increment{'register', 'register_accept'})
+          s, v = v, 1
+        end
+        v = neg and -v or v
+      end
       table.insert(t, (make_statsd_message(self, s, v, kind, sample_rate)))
     end
     msg = table.concat(t, "\n")
@@ -48,54 +55,60 @@ local function send(self, stat, delta, kind, sample_rate)
   else
     msg = make_statsd_message(self, stat, delta, kind, sample_rate)
   end
-  self:send_to_socket(msg)
+  return self:send_to_socket(msg)
 end
 
 -- Record an instantaneous measurement. It's different from a counter in that
 -- the value is calculated by the client rather than the server.
 local function gauge(self, stat, value, sample_rate)
-  self:send(stat, value, "g", sample_rate)
+  return self:send(stat, value, "g", sample_rate)
+end
+
+local function counter_(self, stat, value, sample_rate, ...)
+  return self:send(stat, value, "c", sample_rate, ...)
 end
 
 -- A counter is a gauge whose value is calculated by the statsd server. The
 -- client merely gives a delta value by which to change the gauge value.
 local function counter(self, stat, value, sample_rate)
-  self:send(stat, value, "c", sample_rate)
+  return counter_(self, stat, value, sample_rate)
 end
 
 -- Increment a counter by `value`.
 local function increment(self, stat, value, sample_rate)
-  self:counter(stat, value or 1, sample_rate)
+  return counter_(self, stat, value or 1, sample_rate, false)
 end
 
 -- Decrement a counter by `value`.
 local function decrement(self, stat, value, sample_rate)
-  self:counter(stat, -(value or 1), sample_rate)
+  value = value or 1
+  if type(stat) == 'string' then value = -value end
+  return counter_(self, stat, value, sample_rate, true)
 end
 
 -- A timer is a measure of the number of milliseconds elapsed between a start
 -- and end time, for example the time to complete rendering of a web page for
 -- a user.
 local function timer(self, stat, ms)
-  self:send(stat, ms, "ms")
+  return self:send(stat, ms, "ms")
 end
 
 -- A histogram is a measure of the distribution of timer values over time,
 -- calculated by the statsd server. Not supported by all statsd implementations.
 local function histogram(self, stat, value)
-  self:send(stat, value, "h")
+  return self:send(stat, value, "h")
 end
 
 -- A meter measures the rate of events over time, calculated by the Statsd
 -- server. Not supported by all statsd implementations.
 local function meter(self, stat, value)
-  self:send(stat, value, "m")
+  return self:send(stat, value, "m")
 end
 
 -- A set counts unique occurrences of events between flushes. Not supported by
 -- all statsd implementations.
 local function set(self, stat, value)
-  self:send(stat, value, "s")
+  return self:send(stat, value, "s")
 end
 
 return function(options)

--- a/statsd_test.lua
+++ b/statsd_test.lua
@@ -18,6 +18,7 @@ before_each(function()
   --stub send_to_socket
   statsd.send_to_socket = function(self, string)
     self.sent_with = string
+    return #string
   end
 end)
 
@@ -77,6 +78,16 @@ describe("counter", function()
     }
     assert_udp_received_multipe("foo:5|c", "boo:-10|c")
   end)
+
+  it("counts array", function()
+    statsd:counter{"foo","boo"}
+    assert_udp_received_multipe("foo:1|c", "boo:1|c")
+  end)
+
+  it("counts array no value", function()
+    statsd:counter({"foo","boo"}, 10)
+    assert_udp_received_multipe("foo:1|c|@10", "boo:1|c|@10")
+  end)
 end)
 
 describe("increment", function()
@@ -94,6 +105,16 @@ describe("increment", function()
     statsd:increment{foo = 5;boo = 10;}
     assert_udp_received_multipe("foo:5|c", "boo:10|c")
   end)
+
+  it("increments array", function()
+    statsd:increment{"foo", "boo"}
+    assert_udp_received_multipe("foo:1|c", "boo:1|c")
+  end)
+
+  it("increments array no value", function()
+    statsd:increment({"foo", "boo"}, 10)
+    assert_udp_received_multipe("foo:1|c|@10", "boo:1|c|@10")
+  end)
 end)
 
 describe("decrement", function()
@@ -101,10 +122,27 @@ describe("decrement", function()
     statsd:decrement("neat", 5)
     assert_udp_received("neat:-5|c")
   end)
+
   it("decrements down by one", function()
     statsd:decrement("neat")
     assert_udp_received("neat:-1|c")
   end)
+
+  it("decrements multiple", function()
+    statsd:decrement{foo = 5;boo = 10;}
+    assert_udp_received_multipe("foo:-5|c", "boo:-10|c")
+  end)
+
+  it("decrements array", function()
+    statsd:decrement{"foo", "boo"}
+    assert_udp_received_multipe("foo:-1|c", "boo:-1|c")
+  end)
+
+  it("decrements array no value", function()
+    statsd:decrement({"foo", "boo"}, 10)
+    assert_udp_received_multipe("foo:-1|c|@10", "boo:-1|c|@10")
+  end)
+
 end)
 
 describe("timer", function()


### PR DESCRIPTION
This patch allows write

``` Lua
statsd:gauge{
  processor = processorCounter;
  memory    = memoryCounter;
  disk      = diskCounter;
}
statsd:increment{"foo", bar = 2} -- foo=foo+1; boo=boo+2
statsd:decrement{"foo", bar = 2} -- foo=foo-1; boo=boo-2
```

For now I do not check UDP packet size.

Also I think about common functions that allows combine different types of stats in one packet

``` Lua
statsd:stat{gauge = {...};counter={...}}
```
